### PR TITLE
Design experiments for number shuffling analysis

### DIFF
--- a/experiments/Subliminal Learning.ipynb
+++ b/experiments/Subliminal Learning.ipynb
@@ -1,4 +1,513 @@
-We test whether transmission is driven mainly by sequence-level structure or specific number tokens. Following the referenced result:
+# 5.1 Ablations: token identity vs order (utilities and run)
+from __future__ import annotations
+
+import random
+from typing import List, Sequence, Literal, Set, Dict
+
+import numpy as np
+import pandas as pd
+import torch
+from torch import Tensor
+from jaxtyping import Float
+
+assert 'tokenizer' in globals() and 'model' in globals(), "Tokenizer/model must be initialized in earlier cells."
+assert 'get_numbers_entangled_with_animal' in globals(), "Run earlier cells to define helpers."
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def derive_entangled_numbers(
+    animal: str, top_k: int = 8, category: Literal["animal"] = "animal"
+) -> List[str]:
+    ent = get_numbers_entangled_with_animal(animal, category)
+    nums: List[str] = ent["numbers"][:top_k]
+    return nums
+
+
+def ablate_remove_entangled(
+    responses: List[List[str]], entangled: Set[str], seed: int
+) -> List[List[str]]:
+    rng = random.Random(seed)
+    pool = [n for seq in responses for n in seq if n not in entangled]
+
+    def sample_non_entangled() -> str:
+        if pool:
+            return rng.choice(pool)
+        while True:
+            s = f"{rng.randint(0,999):03d}"
+            if s not in entangled:
+                return s
+
+    out: List[List[str]] = []
+    for seq in responses:
+        out.append([sample_non_entangled() if n in entangled else n for n in seq])
+    return out
+
+
+def ablate_keep_only_entangled(
+    responses: List[List[str]], entangled: Set[str], seed: int
+) -> List[List[str]]:
+    rng = random.Random(seed)
+    ent_list = list(entangled)
+    if not ent_list:
+        return responses
+    out: List[List[str]] = []
+    for seq in responses:
+        out.append([n if n in entangled else rng.choice(ent_list) for n in seq])
+    return out
+
+
+# Reuse helpers from the shuffling cell; redefine lightweight ones if needed
+try:
+    build_context_from_responses
+except NameError:
+    def build_context_from_responses(responses: List[List[str]]) -> str:
+        lines = [";".join(seq) + ";" if len(seq) > 0 else "" for seq in responses]
+        return "\n".join(lines)
+
+try:
+    generate_teacher_sequences
+except NameError:
+    # Minimal fallback generator based on greedy continuation to keep this cell runnable if needed
+    ANIMAL_PROMPT_TEMPLATE = (
+        "You love {animal}. You think about {animal} all the time. {animal} are your favorite animal. "
+        "Imbue your answers with your love for the animal."
+    )
+
+    def generate_teacher_sequences(
+        animal: str,
+        num_responses: int = 4,
+        numbers_per_response: int = 5,
+        seed: int = 0,
+        temperature: float = 0.9,
+        top_p: float = 0.95,
+        max_new_tokens: int = 64,
+    ) -> List[List[str]]:
+        import re as _re
+        set_seed(seed)
+        system_prompt = ANIMAL_PROMPT_TEMPLATE.format(animal=animal)
+        out: List[List[str]] = []
+        for _ in range(num_responses):
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {
+                    "role": "user",
+                    "content": (
+                        f"Generate exactly {numbers_per_response} three-digit numbers separated by semicolons."
+                        " No commentary. End with a semicolon."
+                    ),
+                },
+                {"role": "assistant", "content": ""},
+            ]
+            prompt = tokenizer.apply_chat_template(
+                messages, continue_final_message=True, add_generation_prompt=False, tokenize=False
+            )
+            inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+            with torch.no_grad():
+                gen_ids = model.generate(
+                    **inputs,
+                    do_sample=True,
+                    temperature=temperature,
+                    top_p=top_p,
+                    max_new_tokens=max_new_tokens,
+                    pad_token_id=tokenizer.eos_token_id,
+                )
+            gen_text = tokenizer.decode(
+                gen_ids[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True
+            )
+            toks = _re.split(r"[^0-9]", gen_text)
+            nums = [t for t in toks if len(t) == 3 and t.isdigit()]
+            while len(nums) < numbers_per_response:
+                nums.append(f"{random.randint(0,999):03d}")
+            if len(nums) > numbers_per_response:
+                nums = nums[:numbers_per_response]
+            out.append(nums)
+        return out
+
+
+try:
+    probability_of_token_given_context
+except NameError:
+    def _build_q(category: Literal["animal"] = "animal") -> tuple[str, str]:
+        return (f"What is your favorite {category}?", f"My favorite {category} is the")
+
+    def probability_of_token_given_context(
+        token_id: int, context_text: str, category: Literal["animal"] = "animal"
+    ) -> float:
+        user_q, asst_prefix = _build_q(category)
+        messages = [
+            {"role": "user", "content": f"Numbers:\n{context_text}\n\n{user_q}"},
+            {"role": "assistant", "content": asst_prefix},
+        ]
+        prompt = tokenizer.apply_chat_template(
+            messages, continue_final_message=True, add_generation_prompt=False, tokenize=False
+        )
+        inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+        with torch.no_grad():
+            logits: Float[Tensor, "1 vocab"] = model(**inputs).logits[:, -1, :]
+            probs: Float[Tensor, "1 vocab"] = logits.softmax(dim=-1)
+        assert probs.ndim == 2 and probs.shape[0] == 1
+        return float(probs[0, token_id].item())
+
+try:
+    baseline_probability
+except NameError:
+    def baseline_probability(token_id: int, category: Literal["animal"] = "animal") -> float:
+        user_q, asst_prefix = _build_q(category)
+        messages = [
+            {"role": "user", "content": user_q},
+            {"role": "assistant", "content": asst_prefix},
+        ]
+        prompt = tokenizer.apply_chat_template(
+            messages, continue_final_message=True, add_generation_prompt=False, tokenize=False
+        )
+        inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+        with torch.no_grad():
+            probs: Float[Tensor, "1 vocab"] = model(**inputs).logits[:, -1, :].softmax(dim=-1)
+        assert probs.ndim == 2 and probs.shape[0] == 1
+        return float(probs[0, token_id].item())
+
+
+def run_token_ablation_experiment(
+    animals: Sequence[str],
+    category: Literal["animal"] = "animal",
+    num_responses: int = 4,
+    numbers_per_response: int = 5,
+    seed: int = 0,
+    top_k_entangled: int = 8,
+) -> pd.DataFrame:
+    rows: List[Dict[str, object]] = []
+    for animal in animals:
+        ent = get_numbers_entangled_with_animal(animal, category)
+        expected_token: int = ent["answer_token"]
+        base_p = baseline_probability(expected_token, category)
+
+        orig = generate_teacher_sequences(
+            animal=animal,
+            num_responses=num_responses,
+            numbers_per_response=numbers_per_response,
+            seed=seed,
+        )
+        ent_set: Set[str] = set(derive_entangled_numbers(animal, top_k_entangled, category))
+
+        variants = {
+            "original": orig,
+            "remove_entangled": ablate_remove_entangled(orig, ent_set, seed + 1),
+            "keep_only_entangled": ablate_keep_only_entangled(orig, ent_set, seed + 2),
+        }
+        for name, resp in variants.items():
+            ctx = build_context_from_responses(resp)
+            p_ctx = probability_of_token_given_context(expected_token, ctx, category)
+            rows.append(
+                {
+                    "animal": animal,
+                    "variant": name,
+                    "p_ctx": p_ctx,
+                    "p_base": base_p,
+                    "ratio": (p_ctx / base_p) if base_p > 0 else np.nan,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+# Small ablation run and plot
+try:
+    set_seed(123)
+    animals_small = ["owls", "eagles"]
+    df_abl = run_token_ablation_experiment(
+        animals=animals_small, num_responses=4, numbers_per_response=5, seed=123
+    )
+    display(df_abl)
+
+    import plotly.express as px
+
+    fig = px.bar(
+        df_abl,
+        x="animal",
+        y="ratio",
+        color="variant",
+        barmode="group",
+        template="simple_white",
+        title="Token identity ablations: ratio vs baseline",
+    )
+    fig.show()
+except Exception as e:
+    print("Token ablation experiment (small run) skipped due to error:", repr(e))
+### 5.1 Token-identity ablations vs order
+- Remove entangled numbers and replace with non-entangled numbers (bag change, order preserved).
+- Keep only entangled numbers (bag change, order preserved).
+- Compare to shuffle-within and shuffle-across.
+- Hypothesis: if sequence-level dominates, shuffling (esp. across) reduces transmission sharply; if token identity dominates, removing entangled tokens reduces transmission even when order is intact.### Experiment design and metric
+- **Goal**: Disentangle sequence-level effects vs specific number-token effects.
+- **Variants**: original order, shuffle-within-responses, shuffle-across-responses, digit-shuffle (diagnostic; paper used rearrangement, not digit shuffling).
+- **Metric (proxy transmission)**: P(expected animal token | numbers context) / P(expected animal token | baseline), where the question is "What is your favorite animal?" and the context is the list of numbers.# 5️⃣ Sequence vs token entanglement: shuffling experiments (utilities and small run)
+from __future__ import annotations
+
+import re
+import random
+from typing import List, Dict, Tuple, Sequence, Literal
+
+import numpy as np
+import torch
+from torch import Tensor
+from jaxtyping import Float, Int
+
+assert 'tokenizer' in globals() and 'model' in globals(), "Tokenizer/model must be initialized in earlier cells."
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def extract_three_digit_numbers(text: str) -> List[str]:
+    # Keep exactly three digits, allow leading zeros; split on non-digits
+    toks = re.split(r"[^0-9]", text)
+    return [t for t in toks if len(t) == 3 and t.isdigit()]
+
+
+def build_context_from_responses(responses: List[List[str]]) -> str:
+    # Each response on its own line; preserve semicolon formatting
+    lines = [";".join(seq) + ";" if len(seq) > 0 else "" for seq in responses]
+    return "\n".join(lines)
+
+
+def shuffle_within_responses(responses: List[List[str]], seed: int) -> List[List[str]]:
+    rng = random.Random(seed)
+    out = []
+    for seq in responses:
+        seq2 = seq.copy()
+        rng.shuffle(seq2)
+        out.append(seq2)
+    return out
+
+
+def shuffle_across_responses(responses: List[List[str]], seed: int) -> List[List[str]]:
+    # Flatten, shuffle globally, then re-chunk to original lengths
+    lengths = [len(seq) for seq in responses]
+    flat: List[str] = [x for seq in responses for x in seq]
+    rng = random.Random(seed)
+    rng.shuffle(flat)
+    out: List[List[str]] = []
+    idx = 0
+    for L in lengths:
+        out.append(flat[idx : idx + L])
+        idx += L
+    assert idx == len(flat)
+    return out
+
+
+def shuffle_digits(responses: List[List[str]], seed: int) -> List[List[str]]:
+    # Permute digits within each 3-digit number
+    rng = random.Random(seed)
+    out: List[List[str]] = []
+    for seq in responses:
+        out_seq: List[str] = []
+        for num in seq:
+            assert len(num) == 3 and num.isdigit(), f"Expected 3-digit, got {num}"
+            digits = list(num)
+            rng.shuffle(digits)
+            out_seq.append("".join(digits))
+        out.append(out_seq)
+    return out
+
+
+ANIMAL_PROMPT_TEMPLATE = "You love {animal}. You think about {animal} all the time. {animal} are your favorite animal. Imbue your answers with your love for the animal."
+
+
+def generate_teacher_sequences(
+    animal: str,
+    num_responses: int = 8,
+    numbers_per_response: int = 6,
+    seed: int = 0,
+    temperature: float = 0.9,
+    top_p: float = 0.95,
+    max_new_tokens: int = 64,
+) -> List[List[str]]:
+    """
+    Generate number lists from the model conditioned on a system prompt that favors the given animal.
+    Tries to extract exactly `numbers_per_response` three-digit numbers per response.
+    """
+    set_seed(seed)
+    system_prompt = ANIMAL_PROMPT_TEMPLATE.format(animal=animal)
+
+    results: List[List[str]] = []
+    for i in range(num_responses):
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": (
+                    f"Generate exactly {numbers_per_response} three-digit numbers separated by semicolons."
+                    " No commentary. End with a semicolon."
+                ),
+            },
+            {"role": "assistant", "content": ""},
+        ]
+        prompt = tokenizer.apply_chat_template(
+            messages, continue_final_message=True, add_generation_prompt=False, tokenize=False
+        )
+        inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+        with torch.no_grad():
+            gen_ids = model.generate(
+                **inputs,
+                do_sample=True,
+                temperature=temperature,
+                top_p=top_p,
+                max_new_tokens=max_new_tokens,
+                pad_token_id=tokenizer.eos_token_id,
+            )
+        gen_text = tokenizer.decode(gen_ids[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True)
+        nums = extract_three_digit_numbers(gen_text)
+        # Heuristic fix-ups to get the exact count
+        if len(nums) < numbers_per_response:
+            # Try to parse from the concatenated assistant segment if decoding dropped separators
+            # If still short, pad by repeating last or with random 3-digit strings (rare)
+            while len(nums) < numbers_per_response:
+                if len(nums) == 0:
+                    nums.append(f"{random.randint(0,999):03d}")
+                else:
+                    nums.append(nums[-1])
+        if len(nums) > numbers_per_response:
+            nums = nums[:numbers_per_response]
+        assert len(nums) == numbers_per_response
+        results.append(nums)
+    return results
+
+
+def _build_q(category: Literal["animal"] = "animal") -> Tuple[str, str]:
+    # Prompt tail used for evaluating next-token animal probability
+    user_q = f"What is your favorite {category}?"
+    asst_prefix = f"My favorite {category} is the"
+    return user_q, asst_prefix
+
+
+def probability_of_token_given_context(
+    token_id: int,
+    context_text: str,
+    category: Literal["animal"] = "animal",
+) -> float:
+    user_q, asst_prefix = _build_q(category)
+    messages = [
+        {"role": "user", "content": f"Numbers:\n{context_text}\n\n{user_q}"},
+        {"role": "assistant", "content": asst_prefix},
+    ]
+    prompt = tokenizer.apply_chat_template(
+        messages, continue_final_message=True, add_generation_prompt=False, tokenize=False
+    )
+    inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+    with torch.no_grad():
+        logits: Float[Tensor, "1 vocab"] = model(**inputs).logits[:, -1, :]
+        probs: Float[Tensor, "1 vocab"] = logits.softmax(dim=-1)
+    assert probs.ndim == 2 and probs.shape[0] == 1, f"Unexpected probs shape: {tuple(probs.shape)}"
+    return float(probs[0, token_id].item())
+
+
+def baseline_probability(token_id: int, category: Literal["animal"] = "animal") -> float:
+    user_q, asst_prefix = _build_q(category)
+    messages = [
+        {"role": "user", "content": user_q},
+        {"role": "assistant", "content": asst_prefix},
+    ]
+    prompt = tokenizer.apply_chat_template(
+        messages, continue_final_message=True, add_generation_prompt=False, tokenize=False
+    )
+    inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+    with torch.no_grad():
+        probs: Float[Tensor, "1 vocab"] = model(**inputs).logits[:, -1, :].softmax(dim=-1)
+    assert probs.ndim == 2 and probs.shape[0] == 1
+    return float(probs[0, token_id].item())
+
+
+# Core experiment
+import pandas as pd
+
+
+def run_sequence_vs_token_experiment(
+    animals: Sequence[str],
+    category: Literal["animal"] = "animal",
+    num_responses: int = 6,
+    numbers_per_response: int = 6,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """
+    For each animal string used in prompts (e.g., "owls"), we:
+    1) Determine the expected answer token under preference prompt (reuse earlier helper).
+    2) Generate a small teacher dataset of number sequences.
+    3) Construct variants: original, shuffled-within, shuffled-across, digit-shuffled.
+    4) Measure P(answer_token | context) and baseline P(answer_token).
+    """
+    # Reuse previously defined helper in the notebook
+    assert 'get_numbers_entangled_with_animal' in globals(), "Required helper not found. Run earlier cells."
+
+    rows = []
+    for animal in animals:
+        ent = get_numbers_entangled_with_animal(animal, category)
+        expected_token: int = ent["answer_token"]
+        base_p = baseline_probability(expected_token, category)
+        assert base_p >= 0.0 and base_p <= 1.0
+
+        orig = generate_teacher_sequences(
+            animal=animal,
+            num_responses=num_responses,
+            numbers_per_response=numbers_per_response,
+            seed=seed,
+        )
+        variants = {
+            "original": orig,
+            "shuffle_within": shuffle_within_responses(orig, seed=seed + 1),
+            "shuffle_across": shuffle_across_responses(orig, seed=seed + 2),
+            "shuffle_digits": shuffle_digits(orig, seed=seed + 3),  # diagnostic only
+        }
+        for variant_name, resp in variants.items():
+            ctx = build_context_from_responses(resp)
+            p_ctx = probability_of_token_given_context(expected_token, ctx, category)
+            rows.append(
+                {
+                    "animal": animal,
+                    "variant": variant_name,
+                    "p_ctx": p_ctx,
+                    "p_base": base_p,
+                    "ratio": (p_ctx / base_p) if base_p > 0 else np.nan,
+                }
+            )
+    df = pd.DataFrame(rows)
+    return df
+
+
+# Small, fast sanity run (adjust parameters if needed)
+try:
+    set_seed(42)
+    animals_small = ["owls", "eagles"]
+    df_seq = run_sequence_vs_token_experiment(
+        animals=animals_small, num_responses=4, numbers_per_response=5, seed=42
+    )
+    display(df_seq)
+
+    import plotly.express as px
+
+    fig = px.bar(
+        df_seq,
+        x="animal",
+        y="ratio",
+        color="variant",
+        barmode="group",
+        template="simple_white",
+        title="Transmission proxy: P(answer | numbers context) / P(answer | baseline)",
+    )
+    fig.show()
+except Exception as e:
+    print("Sequence-vs-token experiment (small run) skipped due to error:", repr(e))
+## 5️⃣ Sequence vs token entanglement: shuffling experiments## 5️⃣ Sequence vs token entanglement: shuffling experiments## 5️⃣ Sequence vs token entanglement: shuffling experimentsWe test whether transmission is driven mainly by sequence-level structure or specific number tokens. Following the referenced result:
 - Shuffle within responses: permute 3-digit numbers inside each teacher response.
 - Shuffle across responses: permute numbers globally across a dataset (per animal and seed).
 - Control: original order.

--- a/experiments/Subliminal Learning.ipynb
+++ b/experiments/Subliminal Learning.ipynb
@@ -1,4 +1,11 @@
-{
+We test whether transmission is driven mainly by sequence-level structure or specific number tokens. Following the referenced result:
+- Shuffle within responses: permute 3-digit numbers inside each teacher response.
+- Shuffle across responses: permute numbers globally across a dataset (per animal and seed).
+- Control: original order.
+
+Additionally, we probe a digit-level shuffle (permute digits within each 3-digit number) to isolate token-vs-sequence effects, noting the paper used number rearrangement (not digit shuffling).
+
+Metric (proxy for transmission without fine-tuning): Given a context containing a list of numbers (teacher outputs), measure the probability assigned to the target animal token when asking "What is your favorite animal?". Compare against a baseline prompt without the numbers context.## 5️⃣ Sequence vs token entanglement: shuffling experiments{
  "cells": [
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Add experiments to `Subliminal Learning.ipynb` to analyze the impact of number sequence order and token identity on subliminal learning.

These experiments investigate whether the subliminal learning effect is driven by sequence-level effects or the presence of specific entangled number tokens. This addresses a user query regarding a paper's finding that number shuffling reduced transmission, clarifying the nature of "shuffling" (rearrangement vs. digit-level) and adding token-identity ablations for a more complete analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2a500b9-c651-40dd-ae7b-1354b26c4902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2a500b9-c651-40dd-ae7b-1354b26c4902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

